### PR TITLE
Enforce: only allow PRs from staging to main

### DIFF
--- a/.github/workflows/enforce-staging-to-main.yml
+++ b/.github/workflows/enforce-staging-to-main.yml
@@ -1,0 +1,15 @@
+name: Enforce staging as only source for main
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if PR source is not staging
+        run: |
+          if [ "${{ github.head_ref }}" != "staging" ]; then
+            echo "Only PRs from 'staging' may be merged into 'main'."
+            exit 1
+          fi


### PR DESCRIPTION
This adds a workflow that fails any PR into main unless the head branch is exactly `staging`.

After merging, add this workflow check as a required status check in the `main` branch protection.